### PR TITLE
#9 Handle JWT Token Using Cookies in Both Frontend and Backend.

### DIFF
--- a/aluminiconnector-backend/lib/constant.js
+++ b/aluminiconnector-backend/lib/constant.js
@@ -1,0 +1,8 @@
+const cookieOptions = {
+  httpOnly: true,
+  secure: true,
+  maxAge: 3600000, // Expires in 1 hour
+  sameSite: "Lax",
+};
+
+module.exports = cookieOptions;

--- a/aluminiconnector-backend/routes/auth.js
+++ b/aluminiconnector-backend/routes/auth.js
@@ -5,6 +5,7 @@ const User = require("../models/User");
 const Post = require("../models/Post");
 const Chat = require("../models/Chat");
 const router = express.Router();
+const cookieOptions = require("../lib/constant");
 
 // Sign Up
 router.post("/signup", async (req, res) => {
@@ -12,6 +13,9 @@ router.post("/signup", async (req, res) => {
   const hashedPassword = await bcrypt.hash(password, 10);
   const user = new User({ username, password: hashedPassword, college });
   await user.save();
+  const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET);
+  //later after setting up complete directory setup this can be done in some helping hooks.
+  res.cookie("auth_session", token, cookieOptions);
   res.status(201).send("User created");
 });
 
@@ -25,13 +29,11 @@ router.post("/login", async (req, res) => {
   const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, {
     expiresIn: "1h",
   });
-  //this will be good even the schema changes in future
-  res.cookie("auth_session", token, {
-    httpOnly: true, //it will be httponly & not applied on document.cookie
-    secure: true,
-    maxAge: 3600000, // Expires in 1 hour
-    sameSite: "Lax",
-  });
+
+  //this will be good even the schema
+  //later after setting up complete directory setup this can be done in some helping hooks.
+  changes in future;
+  res.cookie("auth_session", token, cookieOptions);
   res.json({ token, college: user.college, userId: user._id });
 });
 


### PR DESCRIPTION
This PR addresses issue #9 by introducing a secure method of handling JWT tokens using HTTP-only cookies on  the backend. The changes improve the security and management of user sessions.
